### PR TITLE
Add package.json with minify script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.log

--- a/loadCSS.min.js
+++ b/loadCSS.min.js
@@ -1,1 +1,1 @@
-function loadCSS(e,t,n){"use strict";var r=window.document.createElement("link");var i=t||window.document.getElementsByTagName("script")[0];r.rel="stylesheet";r.href=e;r.media="only x";i.parentNode.insertBefore(r,i);setTimeout(function(){r.media=n||"all"})}
+function loadCSS(e,t,n){"use strict";var i=window.document.createElement("link");var o=t||window.document.getElementsByTagName("script")[0];i.rel="stylesheet";i.href=e;i.media="only x";o.parentNode.insertBefore(i,o);setTimeout(function(){i.media=n||"all"})}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "load-css",
+  "private": true,
+  "main": "loadCSS.js",
+  "scripts": {
+    "minify": "uglifyjs loadCSS.js -m -o loadCSS.min.js"
+  },
+  "devDependencies": {
+    "uglify-js": "2.4.x"
+  }
+}


### PR DESCRIPTION
It'd be nice to have minifications be consistent for any contributor. Here's how to use this:
1. `npm install` to get UglifyJS (done once)
2. `npm run minify` to put minified code in loadCSS.min.js (done every time you want to minify)

That's it!

We might want to update package.json to be publishable to npm, but it's private for now.
