### PR TITLE
Update loadCSS.js

### DIFF
--- a/loadCSS.js
+++ b/loadCSS.js
@@ -13,7 +13,7 @@ function loadCSS( href, before, media ){
 	// If so, pass a different reference element to the `before` argument and it'll insert before that instead
 	// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
 	var ss = window.document.createElement( "link" );
-	var ref = before || window.document.getElementsByTagName( "script" )[ 0 ];
+	var ref = before || window.document.body.getElementsByTagName( "script" )[ 0 ];
 	var sheets = window.document.styleSheets;
 	ss.rel = "stylesheet";
 	ss.href = href;


### PR DESCRIPTION
This can prevent our CSS to be misplaced in case there are script tags right below the html tag.
I had a problem with one of our clients where the "Sidekick by Hubspot" extension for Chrome was placing his scripts below the html tag thus appending my CSS before it. 
This was making my inline CSS to overwrite some of my appended CSS.
