### PR TITLE
Update loadCSS.js

### DIFF
--- a/loadCSS.js
+++ b/loadCSS.js
@@ -14,13 +14,13 @@ function loadCSS( href, before, media ){
 	// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
 	var ss = window.document.createElement( "link" );
 	var ref = before || window.document.getElementsByTagName( "script" )[ 0 ];
-	var sheets = window.document.styleSheets;
 	ss.rel = "stylesheet";
 	ss.href = href;
 	// temporarily, set media to something non-matching to ensure it'll fetch without blocking render
 	ss.media = "only x";
 	// inject link
 	ref.parentNode.insertBefore( ss, ref );
+	var sheets = window.document.styleSheets;
 	// This function sets the link's media back to `all` so that the stylesheet applies once it loads
 	// It is designed to poll until document.styleSheets includes the new sheet.
 	function toggleMedia(){


### PR DESCRIPTION
Fixes a bug where the media attribute would not be set back to "all" when the sheet is loaded if the sheet was inserted as the last one in the document. That is, the "sheets" variable was setup before the new link element is added, and as a result it would not be found in the iteration in the toggleMedia() function.