### PR TITLE
add support for relative URLs and URLs with level-navigation

### DIFF
--- a/loadCSS.js
+++ b/loadCSS.js
@@ -26,7 +26,7 @@ function loadCSS( href, before, media ){
 	function toggleMedia(){
 		var defined;
 		for( var i = 0; i < sheets.length; i++ ){
-			if( sheets[ i ].href && sheets[ i ].href.indexOf( href ) > -1 ){
+			if( sheets[ i ].href && sheets[ i ].href.indexOf( ss.href ) > -1 ){
 				defined = true;
 			}
 		}


### PR DESCRIPTION
Hey,

thanks for this snippet! In my current project i ran into the issue of loading a stylesheet with an absolute URL  with level-navigation (eg. http://example.com/assets/js/../css/styles.css), similar to issue #29 

Here is the fix for it, instead of checking against the parameter (href) check against the property on the created element (the interpreted URL).

### Tests of loading a reset stylesheet:
- http://jsbin.com/nenuga/1/ (loadCSS with absolute URL) *works*
- http://jsbin.com/vixuga/1/ (loadCSS with relative URL) *doesn't work*
- http://jsbin.com/borufa/1/ (fixed loadCSS with relative URL) *works*

Hope this helps others too, maybe worth to be merged in.
cheers