### PR TITLE
Add UMD module loader. Make before and media arguments optional.

### DIFF
--- a/loadCSS.js
+++ b/loadCSS.js
@@ -3,41 +3,55 @@ loadCSS: load a CSS file asynchronously.
 [c]2014 @scottjehl, Filament Group, Inc.
 Licensed MIT
 */
-function loadCSS( href, before, media, callback ){
-	"use strict";
-	// Arguments explained:
-	// `href` is the URL for your CSS file.
-	// `before` optionally defines the element we'll use as a reference for injecting our <link>
-	// By default, `before` uses the first <script> element in the page.
-	// However, since the order in which stylesheets are referenced matters, you might need a more specific location in your document.
-	// If so, pass a different reference element to the `before` argument and it'll insert before that instead
-	// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
-	var ss = window.document.createElement( "link" );
-	var ref = before || window.document.getElementsByTagName( "script" )[ 0 ];
-	var sheets = window.document.styleSheets;
-	ss.rel = "stylesheet";
-	ss.href = href;
-	// temporarily, set media to something non-matching to ensure it'll fetch without blocking render
-	ss.media = "only x";
-	ss.onload = callback || function() {};
-	// inject link
-	ref.parentNode.insertBefore( ss, ref );
-	// This function sets the link's media back to `all` so that the stylesheet applies once it loads
-	// It is designed to poll until document.styleSheets includes the new sheet.
-	function toggleMedia(){
-		var defined;
-		for( var i = 0; i < sheets.length; i++ ){
-			if( sheets[ i ].href && sheets[ i ].href.indexOf( href ) > -1 ){
-				defined = true;
+(function (root, factory) {
+	if (typeof define === "function" && define.amd) {
+		// AMD. Register as an anonymous module.
+		define(factory);
+	} else {
+		// Browser globals
+		root.loadCSS = factory();
+	}
+}(this, function () {
+
+	function loadCSS( href, before, media, callback ){
+		"use strict";
+		// Arguments explained:
+		// `href` is the URL for your CSS file.
+		// `before` optionally defines the element we'll use as a reference for injecting our <link>
+		// By default, `before` uses the first <script> element in the page.
+		// However, since the order in which stylesheets are referenced matters, you might need a more specific location in your document.
+		// If so, pass a different reference element to the `before` argument and it'll insert before that instead
+		// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
+		var ss = window.document.createElement( "link" );
+		var ref = before || window.document.getElementsByTagName( "script" )[ 0 ];
+		var sheets = window.document.styleSheets;
+		ss.rel = "stylesheet";
+		ss.href = href;
+		// temporarily, set media to something non-matching to ensure it'll fetch without blocking render
+		ss.media = "only x";
+		ss.onload = callback || function() {};
+		// inject link
+		ref.parentNode.insertBefore( ss, ref );
+		// This function sets the link's media back to `all` so that the stylesheet applies once it loads
+		// It is designed to poll until document.styleSheets includes the new sheet.
+		function toggleMedia(){
+			var defined;
+			for( var i = 0; i < sheets.length; i++ ){
+				if( sheets[ i ].href && sheets[ i ].href.indexOf( href ) > -1 ){
+					defined = true;
+				}
+			}
+			if( defined ){
+				ss.media = media || "all";
+			}
+			else {
+				setTimeout( toggleMedia );
 			}
 		}
-		if( defined ){
-			ss.media = media || "all";
-		}
-		else {
-			setTimeout( toggleMedia );
-		}
+		toggleMedia();
+		return ss;
 	}
-	toggleMedia();
-	return ss;
-}
+
+	return loadCSS;
+
+}));

--- a/loadCSS.js
+++ b/loadCSS.js
@@ -22,9 +22,17 @@ Licensed MIT
 		// However, since the order in which stylesheets are referenced matters, you might need a more specific location in your document.
 		// If so, pass a different reference element to the `before` argument and it'll insert before that instead
 		// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
-		var ss = window.document.createElement( "link" );
-		var ref = before || window.document.getElementsByTagName( "script" )[ 0 ];
-		var sheets = window.document.styleSheets;
+		if ( typeof before == "string" ) {
+			if ( typeof media == "function" ) {
+				callback = media;
+			}
+			media = before;
+			before = null;
+		}
+		var doc = window.document;
+		var ss = doc.createElement( "link" );
+		var ref = before || doc.getElementsByTagName( "script" )[ 0 ];
+		var sheets = doc.styleSheets;
 		ss.rel = "stylesheet";
 		ss.href = href;
 		// temporarily, set media to something non-matching to ensure it'll fetch without blocking render

--- a/loadCSS.js
+++ b/loadCSS.js
@@ -22,10 +22,11 @@ Licensed MIT
 		// However, since the order in which stylesheets are referenced matters, you might need a more specific location in your document.
 		// If so, pass a different reference element to the `before` argument and it'll insert before that instead
 		// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
-		if ( typeof before == "string" ) {
-			if ( typeof media == "function" ) {
-				callback = media;
-			}
+		if ( "function" == typeof before ) {
+			callback = before;
+			before = null;
+		} else if ( "string" == typeof before ) {
+			callback = media;
 			media = before;
 			before = null;
 		}

--- a/loadCSS.js
+++ b/loadCSS.js
@@ -12,9 +12,9 @@ Licensed MIT
 		root.loadCSS = factory();
 	}
 }(this, function () {
+	"use strict";
 
-	function loadCSS( href, before, media, callback ){
-		"use strict";
+	return function loadCSS( href, before, media, callback ){
 		// Arguments explained:
 		// `href` is the URL for your CSS file.
 		// `before` optionally defines the element we'll use as a reference for injecting our <link>
@@ -58,8 +58,5 @@ Licensed MIT
 		}
 		toggleMedia();
 		return ss;
-	}
-
-	return loadCSS;
-
+	};
 }));

--- a/loadCSS.js
+++ b/loadCSS.js
@@ -22,13 +22,18 @@ Licensed MIT
 		// However, since the order in which stylesheets are referenced matters, you might need a more specific location in your document.
 		// If so, pass a different reference element to the `before` argument and it'll insert before that instead
 		// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
-		if ( "function" == typeof before ) {
-			callback = before;
-			before = null;
-		} else if ( "string" == typeof before ) {
+		if ( "string" == typeof before ) {
 			callback = media;
 			media = before;
 			before = null;
+		}
+		if ( "function" == typeof before ) {
+			callback = before;
+			before = media = null;
+		}
+		if ( "function" == typeof media ) {
+			callback = media;
+			media = null;
 		}
 		var doc = window.document;
 		var ss = doc.createElement( "link" );


### PR DESCRIPTION
I've wrapped the function in the [UMD AMDweb loader](https://github.com/umdjs/umd/blob/master/amdWeb.js).
Also updated the arguments so you don't need to pass in the `before` or `media` arguments. Eg:

```js
// Before
loadCSS('url', someNode, 'braille', someFn);
loadCSS('url', someNode, null, someFn);
loadCSS('url', null, 'braille', someFn);
loadCSS('url', null, null, someFn);

// After
loadCSS('url', someNode, 'braille', someFn);
loadCSS('url', someNode, someFn);
loadCSS('url', 'braille', someFn);
loadCSS('url', someFn);
```
