### PR TITLE
[Fix] Placed comma in correct place.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "grunt": "~0.4.5",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-jshint": "~0.11.0"
-  }
+  },
   "scripts": {
     "test": "node node_modules/.bin/grunt"
-  },
+  }
 }


### PR DESCRIPTION
Package.json isn't valid JSON right now because there isn't a comma after ```devDependencies```. Also there is a comma at the end of ```scripts``` which is out of place.