### PR TITLE
Removing relative path issue

### DIFF
--- a/loadCSS.js
+++ b/loadCSS.js
@@ -33,7 +33,7 @@ function loadCSS( href, before, media, callback ){
 	ss.onloadcssdefined = function( cb ){
 		var defined;
 		for( var i = 0; i < sheets.length; i++ ){
-			if( sheets[ i ].href && sheets[ i ].href.indexOf( href ) > -1 ){
+			if( sheets[ i ].href && sheets[ i ].href.indexOf( href.replace('../','') ) > -1 ){
 				defined = true;
 			}
 		}


### PR DESCRIPTION
When a file was called with ../assets/global.css the resulting path is base/anything/assets/global.css. Therefore there will be no matching which is fixed with this update.