### PR TITLE
85

### DIFF
--- a/loadCSS.js
+++ b/loadCSS.js
@@ -9,13 +9,25 @@ function loadCSS( href, before, media ){
 	"use strict";
 	// Arguments explained:
 	// `href` is the URL for your CSS file.
-	// `before` optionally defines the element we'll use as a reference for injecting our <link>
-	// By default, `before` uses the first <script> element in the page.
-	// However, since the order in which stylesheets are referenced matters, you might need a more specific location in your document.
+	// `before` optionally defines the element we'll use as a reference for injecting our <link> before
+	// By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM
+	// However, you might desire a more specific location in your document.
 	// If so, pass a different reference element to the `before` argument and it'll insert before that instead
 	// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
 	var ss = window.document.createElement( "link" );
-	var ref = before || window.document.getElementsByTagName( "script" )[ 0 ];
+	var ref;
+	if( before ){
+		ref = before;
+	}
+	else if( window.document.querySelectorAll ){
+		var refs = window.document.querySelectorAll(  "style,link[rel=stylesheet],script" );
+		// no need to check length - this script has a parent element, at least
+		ref = refs[ refs.length - 1];
+	}
+	else {
+		ref = window.document.getElementsByTagName( "script" )[ 0 ];
+	}
+
 	var sheets = window.document.styleSheets;
 	ss.rel = "stylesheet";
 	ss.href = href;
@@ -23,9 +35,10 @@ function loadCSS( href, before, media ){
 	ss.media = "only x";
 
 	// inject link
-	ref.parentNode.insertBefore( ss, ref );
+	// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
+	ref.parentNode.insertBefore( ss, ( before ? ref : ref.nextSibling ) );
 	// This function sets the link's media back to `all` so that the stylesheet applies once it loads
-	// It is designed to poll until document.styleSheets includes the new sheet.
+	// It is designed to poll until window.document.styleSheets includes the new sheet.
 	ss.onloadcssdefined = function( cb ){
 		var defined;
 		for( var i = 0; i < sheets.length; i++ ){

--- a/test/preload.html
+++ b/test/preload.html
@@ -8,7 +8,7 @@
 
 		<link rel="preload" href="http://scottjehl.com/css-temp/slow.php" as="stylesheet" id="asyncCSS" onload="this.rel='stylesheet'">
 
-		<script>
+		<script id="loadCSS">
 
 			// link rel=preload support test via https://lists.w3.org/Archives/Public/public-whatwg-archive/2015Apr/0013.html
 			function preloadSupported() {
@@ -22,23 +22,22 @@
 			[c]2014 @scottjehl, Filament Group, Inc.
 			Licensed MIT
 			*/
+
+			/* exported loadCSS */
 			function loadCSS( href, before, media, callback ){
 				"use strict";
 				// Arguments explained:
-				// `href` is the URL for your CSS file.
-				// `before` optionally defines the element we'll use as a reference for injecting our <link>
-				// By default, `before` uses the first <script> element in the page.
-				// However, since the order in which stylesheets are referenced matters, you might need a more specific location in your document.
-				// If so, pass a different reference element to the `before` argument and it'll insert before that instead
-				// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
+				// `href` REQUIRED. The URL for your CSS file.
+				// `before` REQUIRED. The element to use as a reference for injecting the <link>.
+				// `media` OPTIONAL. Media type or query for the stylesheet. (Will be "all" if not defined)
+				// `callback` OPTIONAL. DEPRECATED. A callback bound to the stylesheet's onload handler. Use onloadcssdefined on return object of loadCSS instead.
 				var ss = window.document.createElement( "link" );
-				var ref = before || window.document.getElementsByTagName( "script" )[ 0 ];
+				var ref = before;
 				var sheets = window.document.styleSheets;
 				ss.rel = "stylesheet";
 				ss.href = href;
 				// temporarily, set media to something non-matching to ensure it'll fetch without blocking render
 				ss.media = "only x";
-				// DEPRECATED
 				if( callback ) {
 					ss.onload = callback;
 				}
@@ -50,7 +49,7 @@
 				ss.onloadcssdefined = function( cb ){
 					var defined;
 					for( var i = 0; i < sheets.length; i++ ){
-						if( sheets[ i ].href && sheets[ i ].href.indexOf( href ) > -1 ){
+						if( sheets[ i ].href && sheets[ i ].href === ss.href ){
 							defined = true;
 						}
 					}
@@ -70,9 +69,7 @@
 
 			// if link[rel=preload] is not supported, we must fetch the CSS manually using loadCSS
 			if( !preloadSupported() ){
-				var asyncCSS = window.document.getElementById( "asyncCSS" );
-				// loadCSS, insert just before the link to be sure of its placement in the source
-				loadCSS( asyncCSS.href, asyncCSS );
+				loadCSS( asyncCSS.href, document.getElementById( "loadCSS" ) );
 			}
 
 		</script>

--- a/test/preload.html
+++ b/test/preload.html
@@ -18,34 +18,46 @@
 			}
 
 			/*!
-			loadCSS: load a CSS file asynchronously. (Used for cases where rel=preload is not supported)
+			loadCSS: load a CSS file asynchronously.
 			[c]2014 @scottjehl, Filament Group, Inc.
 			Licensed MIT
 			*/
 
 			/* exported loadCSS */
-			function loadCSS( href, before, media, callback ){
+			function loadCSS( href, before, media ){
 				"use strict";
 				// Arguments explained:
-				// `href` REQUIRED. The URL for your CSS file.
-				// `before` REQUIRED. The element to use as a reference for injecting the <link>.
-				// `media` OPTIONAL. Media type or query for the stylesheet. (Will be "all" if not defined)
-				// `callback` OPTIONAL. DEPRECATED. A callback bound to the stylesheet's onload handler. Use onloadcssdefined on return object of loadCSS instead.
+				// `href` is the URL for your CSS file.
+				// `before` optionally defines the element we'll use as a reference for injecting our <link> before
+				// By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM
+				// However, you might desire a more specific location in your document.
+				// If so, pass a different reference element to the `before` argument and it'll insert before that instead
+				// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
 				var ss = window.document.createElement( "link" );
-				var ref = before;
+				var ref;
+				if( before ){
+					ref = before;
+				}
+				else if( window.document.querySelectorAll ){
+					var refs = window.document.querySelectorAll(  "style,link[rel=stylesheet],script" );
+					// no need to check length - this script has a parent element, at least
+					ref = refs[ refs.length - 1];
+				}
+				else {
+					ref = window.document.getElementsByTagName( "script" )[ 0 ];
+				}
+
 				var sheets = window.document.styleSheets;
 				ss.rel = "stylesheet";
 				ss.href = href;
 				// temporarily, set media to something non-matching to ensure it'll fetch without blocking render
 				ss.media = "only x";
-				if( callback ) {
-					ss.onload = callback;
-				}
 
 				// inject link
-				ref.parentNode.insertBefore( ss, ref );
+				// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
+				ref.parentNode.insertBefore( ss, ( before ? ref : ref.nextSibling ) );
 				// This function sets the link's media back to `all` so that the stylesheet applies once it loads
-				// It is designed to poll until document.styleSheets includes the new sheet.
+				// It is designed to poll until window.document.styleSheets includes the new sheet.
 				ss.onloadcssdefined = function( cb ){
 					var defined;
 					for( var i = 0; i < sheets.length; i++ ){
@@ -66,6 +78,7 @@
 				});
 				return ss;
 			}
+
 
 			// if link[rel=preload] is not supported, we must fetch the CSS manually using loadCSS
 			if( !preloadSupported() ){

--- a/test/qunit/index.html
+++ b/test/qunit/index.html
@@ -8,7 +8,7 @@
 	<link rel="stylesheet" href="./libs/qunit/qunit.css" media="screen">
 	<script src="./libs/qunit/qunit.js"></script>
 	<!-- Load local lib and tests. -->
-	<script src="../../loadCSS.js"></script>
+	<script src="../../loadCSS.js" id="loadCSS"></script>
 	<script src="../../onloadCSS.js"></script>
 	<script src="./tests.js"></script>
 </head>

--- a/test/test-onload.html
+++ b/test/test-onload.html
@@ -3,29 +3,28 @@
 	<head>
 		<title>Blocking Test</title>
 		<meta charset="utf-8">
-		<script>
+		<script id="loadCSS">
 			/*!
 			loadCSS: load a CSS file asynchronously.
 			[c]2014 @scottjehl, Filament Group, Inc.
 			Licensed MIT
 			*/
+
+			/* exported loadCSS */
 			function loadCSS( href, before, media, callback ){
 				"use strict";
 				// Arguments explained:
-				// `href` is the URL for your CSS file.
-				// `before` optionally defines the element we'll use as a reference for injecting our <link>
-				// By default, `before` uses the first <script> element in the page.
-				// However, since the order in which stylesheets are referenced matters, you might need a more specific location in your document.
-				// If so, pass a different reference element to the `before` argument and it'll insert before that instead
-				// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
+				// `href` REQUIRED. The URL for your CSS file.
+				// `before` REQUIRED. The element to use as a reference for injecting the <link>.
+				// `media` OPTIONAL. Media type or query for the stylesheet. (Will be "all" if not defined)
+				// `callback` OPTIONAL. DEPRECATED. A callback bound to the stylesheet's onload handler. Use onloadcssdefined on return object of loadCSS instead.
 				var ss = window.document.createElement( "link" );
-				var ref = before || window.document.getElementsByTagName( "script" )[ 0 ];
+				var ref = before;
 				var sheets = window.document.styleSheets;
 				ss.rel = "stylesheet";
 				ss.href = href;
 				// temporarily, set media to something non-matching to ensure it'll fetch without blocking render
 				ss.media = "only x";
-				// DEPRECATED
 				if( callback ) {
 					ss.onload = callback;
 				}
@@ -37,14 +36,13 @@
 				ss.onloadcssdefined = function( cb ){
 					var defined;
 					for( var i = 0; i < sheets.length; i++ ){
-						if( sheets[ i ].href && sheets[ i ].href.indexOf( href ) > -1 ){
+						if( sheets[ i ].href && sheets[ i ].href === ss.href ){
 							defined = true;
 						}
 					}
 					if( defined ){
 						cb();
-					}
-					else {
+					} else {
 						setTimeout(function() {
 							ss.onloadcssdefined( cb );
 						});
@@ -69,7 +67,7 @@
 				}
 			}
 
-			var ss = loadCSS( "http://www.zachleat.com/test/lastmodified/timeout.php?t=2&lastmodified=1" );
+			var ss = loadCSS( "http://www.zachleat.com/test/lastmodified/timeout.php?t=2&lastmodified=1", document.getElementById( "loadCSS" ) );
 			onloadCSS( ss, function() {
 				document.body.innerHTML += '<h1>onload!!!</h1>';
 			});
@@ -77,6 +75,6 @@
 	</head>
 	<body>
 		<p>This is a test to see whether or not a loadCSS call will block render. This page uses loadCss to load a CSS file that has a 5 second delay built into its server response time. If loadCSS works properly, you should be able to read this text before the page is styled as white text on green background.</p>
-		
+
 </body>
 </html>

--- a/test/test-onload.html
+++ b/test/test-onload.html
@@ -11,28 +11,40 @@
 			*/
 
 			/* exported loadCSS */
-			function loadCSS( href, before, media, callback ){
+			function loadCSS( href, before, media ){
 				"use strict";
 				// Arguments explained:
-				// `href` REQUIRED. The URL for your CSS file.
-				// `before` REQUIRED. The element to use as a reference for injecting the <link>.
-				// `media` OPTIONAL. Media type or query for the stylesheet. (Will be "all" if not defined)
-				// `callback` OPTIONAL. DEPRECATED. A callback bound to the stylesheet's onload handler. Use onloadcssdefined on return object of loadCSS instead.
+				// `href` is the URL for your CSS file.
+				// `before` optionally defines the element we'll use as a reference for injecting our <link> before
+				// By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM
+				// However, you might desire a more specific location in your document.
+				// If so, pass a different reference element to the `before` argument and it'll insert before that instead
+				// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
 				var ss = window.document.createElement( "link" );
-				var ref = before;
+				var ref;
+				if( before ){
+					ref = before;
+				}
+				else if( window.document.querySelectorAll ){
+					var refs = window.document.querySelectorAll(  "style,link[rel=stylesheet],script" );
+					// no need to check length - this script has a parent element, at least
+					ref = refs[ refs.length - 1];
+				}
+				else {
+					ref = window.document.getElementsByTagName( "script" )[ 0 ];
+				}
+
 				var sheets = window.document.styleSheets;
 				ss.rel = "stylesheet";
 				ss.href = href;
 				// temporarily, set media to something non-matching to ensure it'll fetch without blocking render
 				ss.media = "only x";
-				if( callback ) {
-					ss.onload = callback;
-				}
 
 				// inject link
-				ref.parentNode.insertBefore( ss, ref );
+				// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
+				ref.parentNode.insertBefore( ss, ( before ? ref : ref.nextSibling ) );
 				// This function sets the link's media back to `all` so that the stylesheet applies once it loads
-				// It is designed to poll until document.styleSheets includes the new sheet.
+				// It is designed to poll until window.document.styleSheets includes the new sheet.
 				ss.onloadcssdefined = function( cb ){
 					var defined;
 					for( var i = 0; i < sheets.length; i++ ){
@@ -54,6 +66,9 @@
 				return ss;
 			}
 
+
+
+
 			function onloadCSS( ss, callback ) {
 				ss.onload = function() {
 					ss.onload = null;
@@ -67,7 +82,7 @@
 				}
 			}
 
-			var ss = loadCSS( "http://www.zachleat.com/test/lastmodified/timeout.php?t=2&lastmodified=1", document.getElementById( "loadCSS" ) );
+			var ss = loadCSS( "http://www.zachleat.com/test/lastmodified/timeout.php?t=2&lastmodified=1", null );
 			onloadCSS( ss, function() {
 				document.body.innerHTML += '<h1>onload!!!</h1>';
 			});

--- a/test/test.html
+++ b/test/test.html
@@ -3,29 +3,28 @@
 	<head>
 		<title>Blocking Test</title>
 		<meta charset="utf-8">
-		<script>
+		<script id="loadCSS">
 			/*!
 			loadCSS: load a CSS file asynchronously.
 			[c]2014 @scottjehl, Filament Group, Inc.
 			Licensed MIT
 			*/
+
+			/* exported loadCSS */
 			function loadCSS( href, before, media, callback ){
 				"use strict";
 				// Arguments explained:
-				// `href` is the URL for your CSS file.
-				// `before` optionally defines the element we'll use as a reference for injecting our <link>
-				// By default, `before` uses the first <script> element in the page.
-				// However, since the order in which stylesheets are referenced matters, you might need a more specific location in your document.
-				// If so, pass a different reference element to the `before` argument and it'll insert before that instead
-				// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
+				// `href` REQUIRED. The URL for your CSS file.
+				// `before` REQUIRED. The element to use as a reference for injecting the <link>.
+				// `media` OPTIONAL. Media type or query for the stylesheet. (Will be "all" if not defined)
+				// `callback` OPTIONAL. DEPRECATED. A callback bound to the stylesheet's onload handler. Use onloadcssdefined on return object of loadCSS instead.
 				var ss = window.document.createElement( "link" );
-				var ref = before || window.document.getElementsByTagName( "script" )[ 0 ];
+				var ref = before;
 				var sheets = window.document.styleSheets;
 				ss.rel = "stylesheet";
 				ss.href = href;
 				// temporarily, set media to something non-matching to ensure it'll fetch without blocking render
 				ss.media = "only x";
-				// DEPRECATED
 				if( callback ) {
 					ss.onload = callback;
 				}
@@ -37,14 +36,13 @@
 				ss.onloadcssdefined = function( cb ){
 					var defined;
 					for( var i = 0; i < sheets.length; i++ ){
-						if( sheets[ i ].href && sheets[ i ].href.indexOf( href ) > -1 ){
+						if( sheets[ i ].href && sheets[ i ].href === ss.href ){
 							defined = true;
 						}
 					}
 					if( defined ){
 						cb();
-					}
-					else {
+					} else {
 						setTimeout(function() {
 							ss.onloadcssdefined( cb );
 						});
@@ -56,11 +54,11 @@
 				return ss;
 			}
 
-			loadCSS( "http://scottjehl.com/css-temp/slow.php" );
+			loadCSS( "http://scottjehl.com/css-temp/slow.php", document.getElementById( "loadCSS" ) );
 		</script>
 	</head>
 	<body>
 		<p>This is a test to see whether or not a loadCSS call will block render. This page uses loadCss to load a CSS file that has a 5 second delay built into its server response time. If loadCSS works properly, you should be able to read this text before the page is styled as white text on green background.</p>
-		
+
 </body>
 </html>

--- a/test/test.html
+++ b/test/test.html
@@ -4,57 +4,70 @@
 		<title>Blocking Test</title>
 		<meta charset="utf-8">
 		<script id="loadCSS">
-			/*!
-			loadCSS: load a CSS file asynchronously.
-			[c]2014 @scottjehl, Filament Group, Inc.
-			Licensed MIT
-			*/
+		/*!
+		loadCSS: load a CSS file asynchronously.
+		[c]2014 @scottjehl, Filament Group, Inc.
+		Licensed MIT
+		*/
 
-			/* exported loadCSS */
-			function loadCSS( href, before, media, callback ){
-				"use strict";
-				// Arguments explained:
-				// `href` REQUIRED. The URL for your CSS file.
-				// `before` REQUIRED. The element to use as a reference for injecting the <link>.
-				// `media` OPTIONAL. Media type or query for the stylesheet. (Will be "all" if not defined)
-				// `callback` OPTIONAL. DEPRECATED. A callback bound to the stylesheet's onload handler. Use onloadcssdefined on return object of loadCSS instead.
-				var ss = window.document.createElement( "link" );
-				var ref = before;
-				var sheets = window.document.styleSheets;
-				ss.rel = "stylesheet";
-				ss.href = href;
-				// temporarily, set media to something non-matching to ensure it'll fetch without blocking render
-				ss.media = "only x";
-				if( callback ) {
-					ss.onload = callback;
-				}
-
-				// inject link
-				ref.parentNode.insertBefore( ss, ref );
-				// This function sets the link's media back to `all` so that the stylesheet applies once it loads
-				// It is designed to poll until document.styleSheets includes the new sheet.
-				ss.onloadcssdefined = function( cb ){
-					var defined;
-					for( var i = 0; i < sheets.length; i++ ){
-						if( sheets[ i ].href && sheets[ i ].href === ss.href ){
-							defined = true;
-						}
-					}
-					if( defined ){
-						cb();
-					} else {
-						setTimeout(function() {
-							ss.onloadcssdefined( cb );
-						});
-					}
-				};
-				ss.onloadcssdefined(function() {
-					ss.media = media || "all";
-				});
-				return ss;
+		/* exported loadCSS */
+		function loadCSS( href, before, media ){
+			"use strict";
+			// Arguments explained:
+			// `href` is the URL for your CSS file.
+			// `before` optionally defines the element we'll use as a reference for injecting our <link> before
+			// By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM
+			// However, you might desire a more specific location in your document.
+			// If so, pass a different reference element to the `before` argument and it'll insert before that instead
+			// note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
+			var ss = window.document.createElement( "link" );
+			var ref;
+			if( before ){
+				ref = before;
+			}
+			else if( window.document.querySelectorAll ){
+				var refs = window.document.querySelectorAll(  "style,link[rel=stylesheet],script" );
+				// no need to check length - this script has a parent element, at least
+				ref = refs[ refs.length - 1];
+			}
+			else {
+				ref = window.document.getElementsByTagName( "script" )[ 0 ];
 			}
 
-			loadCSS( "http://scottjehl.com/css-temp/slow.php", document.getElementById( "loadCSS" ) );
+			var sheets = window.document.styleSheets;
+			ss.rel = "stylesheet";
+			ss.href = href;
+			// temporarily, set media to something non-matching to ensure it'll fetch without blocking render
+			ss.media = "only x";
+
+			// inject link
+			// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
+			ref.parentNode.insertBefore( ss, ref );
+			// This function sets the link's media back to `all` so that the stylesheet applies once it loads
+			// It is designed to poll until window.document.styleSheets includes the new sheet.
+			ss.onloadcssdefined = function( cb ){
+				var defined;
+				for( var i = 0; i < sheets.length; i++ ){
+					if( sheets[ i ].href && sheets[ i ].href === ss.href ){
+						defined = true;
+					}
+				}
+				if( defined ){
+					cb();
+				} else {
+					setTimeout(function() {
+						ss.onloadcssdefined( cb );
+					});
+				}
+			};
+			ss.onloadcssdefined(function() {
+				ss.media = media || "all";
+			});
+			return ss;
+		}
+
+
+			loadCSS( "http://scottjehl.com/css-temp/slow.php" );
 		</script>
 	</head>
 	<body>


### PR DESCRIPTION
This changes our default insert behavior to insert after the last stylesheet or script in the page if qsa is supported. Otherwise it inserts after the last script. In either case, the insertBefore is performed in the reference element's nextSibling, which serves as an "insertAfter" regardless of whether the reference element has a nextSibling or not (news to me! Verified in IE6+). 

Despite the default behavior change, we've preserved the behavior of the "before" argument, if provided, so that the link is still inserted before that specific element in that case. We may want to standardize on inserting "after" in a later release. Fixes #85.