### PR TITLE
Small rewrite to help Javascript minification tools.

### DIFF
--- a/loadCSS.js
+++ b/loadCSS.js
@@ -13,14 +13,13 @@ Licensed MIT
 			// By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM. However, you might desire a more specific location in your document.
 		// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
 		var doc = w.document;
-		var querySelectorAll = doc.querySelectorAll;
 		var ss = doc.createElement( "link" );
 		var ref;
 		if( before ){
 			ref = before;
 		}
-		else if( querySelectorAll ){
-			var refs = querySelectorAll(  "style,link[rel=stylesheet],script" );
+		else if( doc.querySelectorAll ){
+			var refs = doc.querySelectorAll("style,link[rel=stylesheet],script");
 			// No need to check length. This script has a parent element, at least
 			ref = refs[ refs.length - 1];
 		}

--- a/loadCSS.js
+++ b/loadCSS.js
@@ -39,7 +39,9 @@ Licensed MIT
 			// Note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
 		ref.parentNode.insertBefore( ss, ( before ? ref : ref.nextSibling ) );
 		// A method (exposed on return object for external use) that mimics onload by polling until document.styleSheets until it includes the new sheet.
-		var onloadcssdefined = function( cb ){
+		var onloadcssdefined;
+		onloadcssdefined = function (cb)
+		{
 			var defined;
 			for( var i = 0; i < sheets.length; i++ ){
 				var sheet = sheets[i];


### PR DESCRIPTION
This is a small rewrite to help Javascript minification tools. The comparison has been done with: https://marijnhaverbeke.nl/uglifyjs.

Current version (https://raw.githubusercontent.com/filamentgroup/loadCSS/master/loadCSS.js)
Ugly version:
Old version: 2357 characters
New version: **616** characters
Saved: 1741 (result is 26.1% of original)

Rewritten version (https://raw.githubusercontent.com/dlemstra/loadCSS/minify-optimization/loadCSS.js)
Ugly version:
Old version: 2435 characters
New version: **551** characters
Saved: 1884 (result is 22.6% of original)