### PR TITLE
fix  callback scope

### DIFF
--- a/loadCSS.js
+++ b/loadCSS.js
@@ -55,7 +55,7 @@ Licensed MIT
 		return ss;
 	};
 	// commonjs
-	if( typeof module !== "undefined" ){
+	if( typeof module !== "undefined" && module.exports ){
 		module.exports = loadCSS;
 	}
 	else {

--- a/loadCSS.js
+++ b/loadCSS.js
@@ -39,7 +39,7 @@ Licensed MIT
 			var i = sheets.length;
 			while( i-- ){
 				if( sheets[ i ].href === resolvedHref ){
-					return cb();
+					return cb.call(ss);
 				}
 			}
 			setTimeout(function() {


### PR DESCRIPTION
fix callback scope to match the same as in onloadCSS.

in onLoadCSS() the callback is called using `callback.call( ss )`
the code for browsers without `onload` support (android < 4.4) didn't use this scoping yet. 
this pull request adds the correct scope.

i've also corrected the commonjs check to make the tests go green again