### PR TITLE
110

### DIFF
--- a/loadCSS.js
+++ b/loadCSS.js
@@ -64,8 +64,8 @@ Licensed MIT
 		return ss;
 	};
 	// commonjs
-	if( typeof module !== "undefined" ){
-		module.exports = loadCSS;
+	if( typeof exports !== "undefined" ){
+		exports.loadCSS = loadCSS;
 	}
 	else {
 		w.loadCSS = loadCSS;

--- a/loadCSS.js
+++ b/loadCSS.js
@@ -41,7 +41,7 @@ Licensed MIT
 			var i = sheets.length;
 			while( i-- ){
 				if( sheets[ i ].href === resolvedHref ){
-					return setTimeout(cb);
+					return cb();
 				}
 			}
 			setTimeout(function() {

--- a/loadCSS.js
+++ b/loadCSS.js
@@ -14,6 +14,7 @@ Licensed MIT
 		// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
 		var doc = w.document;
 		var ss = doc.createElement( "link" );
+		var newMedia = media || "all";
 		var ref;
 		if( before ){
 			ref = before;
@@ -29,6 +30,7 @@ Licensed MIT
 		// temporarily set media to something inapplicable to ensure it'll fetch without blocking render
 		ss.media = "only x";
 
+
 		// Inject link
 			// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
 			// Note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
@@ -39,7 +41,7 @@ Licensed MIT
 			var i = sheets.length;
 			while( i-- ){
 				if( sheets[ i ].href === resolvedHref ){
-					return cb();
+					return setTimeout(cb);
 				}
 			}
 			setTimeout(function() {
@@ -48,9 +50,16 @@ Licensed MIT
 		};
 
 		// once loaded, set link's media back to `all` so that the stylesheet applies once it loads
+		if( ss.addEventListener ){
+			ss.addEventListener( "load", function(){
+				this.media = newMedia;
+			});
+		}
 		ss.onloadcssdefined = onloadcssdefined;
 		onloadcssdefined(function() {
-			ss.media = media || "all";
+			if( ss.media !== newMedia ){
+					ss.media = newMedia;
+			}
 		});
 		return ss;
 	};
@@ -62,4 +71,3 @@ Licensed MIT
 		w.loadCSS = loadCSS;
 	}
 }( typeof global !== "undefined" ? global : this ));
-

--- a/loadCSS.js
+++ b/loadCSS.js
@@ -58,7 +58,7 @@ Licensed MIT
 		ss.onloadcssdefined = onloadcssdefined;
 		onloadcssdefined(function() {
 			if( ss.media !== newMedia ){
-					ss.media = newMedia;
+				ss.media = newMedia;
 			}
 		});
 		return ss;

--- a/test/preload.html
+++ b/test/preload.html
@@ -18,62 +18,79 @@
 			}
 
 			/*!
-		loadCSS: load a CSS file asynchronously.
-		[c]2015 @scottjehl, Filament Group, Inc.
-		Licensed MIT
-		*/
-		(function(w){
-			"use strict";
-			/* exported loadCSS */
-			w.loadCSS = function( href, before, media ){
-				// Arguments explained:
-				// `href` [REQUIRED] is the URL for your CSS file.
-				// `before` [OPTIONAL] is the element the script should use as a reference for injecting our stylesheet <link> before
-					// By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM. However, you might desire a more specific location in your document.
-				// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
-				var doc = w.document;
-				var ss = doc.createElement( "link" );
-				var ref;
-				if( before ){
-					ref = before;
+			loadCSS: load a CSS file asynchronously.
+			[c]2015 @scottjehl, Filament Group, Inc.
+			Licensed MIT
+			*/
+			(function(w){
+				"use strict";
+				/* exported loadCSS */
+				var loadCSS = function( href, before, media ){
+					// Arguments explained:
+					// `href` [REQUIRED] is the URL for your CSS file.
+					// `before` [OPTIONAL] is the element the script should use as a reference for injecting our stylesheet <link> before
+						// By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM. However, you might desire a more specific location in your document.
+					// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
+					var doc = w.document;
+					var ss = doc.createElement( "link" );
+					var newMedia = media || "all";
+					var ref;
+					if( before ){
+						ref = before;
+					}
+					else {
+						var refs = ( doc.body || doc.getElementsByTagName( "head" )[ 0 ] ).childNodes;
+						ref = refs[ refs.length - 1];
+					}
+
+					var sheets = doc.styleSheets;
+					ss.rel = "stylesheet";
+					ss.href = href;
+					// temporarily set media to something inapplicable to ensure it'll fetch without blocking render
+					ss.media = "only x";
+
+
+					// Inject link
+						// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
+						// Note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
+					ref.parentNode.insertBefore( ss, ( before ? ref : ref.nextSibling ) );
+					// A method (exposed on return object for external use) that mimics onload by polling until document.styleSheets until it includes the new sheet.
+					var onloadcssdefined = function( cb ){
+						var resolvedHref = ss.href;
+						var i = sheets.length;
+						while( i-- ){
+							if( sheets[ i ].href === resolvedHref ){
+								return setTimeout(cb);
+							}
+						}
+						setTimeout(function() {
+							onloadcssdefined( cb );
+						});
+					};
+
+					// once loaded, set link's media back to `all` so that the stylesheet applies once it loads
+					if( ss.addEventListener ){
+						ss.addEventListener( "load", function(){
+							this.media = newMedia;
+						});
+					}
+					ss.onloadcssdefined = onloadcssdefined;
+					onloadcssdefined(function() {
+						if( ss.media !== newMedia ){
+								ss.media = newMedia;
+						}
+					});
+					return ss;
+				};
+				// commonjs
+				if( typeof module !== "undefined" ){
+					module.exports = loadCSS;
 				}
 				else {
-					var refs = ( doc.body || doc.getElementsByTagName( "head" )[ 0 ] ).childNodes;
-					ref = refs[ refs.length - 1];
+					w.loadCSS = loadCSS;
 				}
+			}( typeof global !== "undefined" ? global : this ));
 
-				var sheets = doc.styleSheets;
-				ss.rel = "stylesheet";
-				ss.href = href;
-				// temporarily set media to something inapplicable to ensure it'll fetch without blocking render
-				ss.media = "only x";
-
-				// Inject link
-					// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
-					// Note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
-				ref.parentNode.insertBefore( ss, ( before ? ref : ref.nextSibling ) );
-				// A method (exposed on return object for external use) that mimics onload by polling until document.styleSheets until it includes the new sheet.
-				var onloadcssdefined = function( cb ){
-					var resolvedHref = ss.href;
-					var i = sheets.length;
-					while( i-- ){
-						if( sheets[ i ].href === resolvedHref ){
-							return cb();
-						}
-					}
-					setTimeout(function() {
-						onloadcssdefined( cb );
-					});
-				};
-
-				// once loaded, set link's media back to `all` so that the stylesheet applies once it loads
-				ss.onloadcssdefined = onloadcssdefined;
-				onloadcssdefined(function() {
-					ss.media = media || "all";
-				});
-				return ss;
-			};
-		}(this));
 
 
 			// if link[rel=preload] is not supported, we must fetch the CSS manually using loadCSS

--- a/test/test-onload.html
+++ b/test/test-onload.html
@@ -12,7 +12,7 @@
 		(function(w){
 			"use strict";
 			/* exported loadCSS */
-			w.loadCSS = function( href, before, media ){
+			var loadCSS = function( href, before, media ){
 				// Arguments explained:
 				// `href` [REQUIRED] is the URL for your CSS file.
 				// `before` [OPTIONAL] is the element the script should use as a reference for injecting our stylesheet <link> before
@@ -20,6 +20,7 @@
 				// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
 				var doc = w.document;
 				var ss = doc.createElement( "link" );
+				var newMedia = media || "all";
 				var ref;
 				if( before ){
 					ref = before;
@@ -35,6 +36,7 @@
 				// temporarily set media to something inapplicable to ensure it'll fetch without blocking render
 				ss.media = "only x";
 
+
 				// Inject link
 					// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
 					// Note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
@@ -45,7 +47,7 @@
 					var i = sheets.length;
 					while( i-- ){
 						if( sheets[ i ].href === resolvedHref ){
-							return cb();
+							return setTimeout(cb);
 						}
 					}
 					setTimeout(function() {
@@ -54,13 +56,28 @@
 				};
 
 				// once loaded, set link's media back to `all` so that the stylesheet applies once it loads
+				if( ss.addEventListener ){
+					ss.addEventListener( "load", function(){
+						this.media = newMedia;
+					});
+				}
 				ss.onloadcssdefined = onloadcssdefined;
 				onloadcssdefined(function() {
-					ss.media = media || "all";
+					if( ss.media !== newMedia ){
+							ss.media = newMedia;
+					}
 				});
 				return ss;
 			};
-		}(this));
+			// commonjs
+			if( typeof module !== "undefined" ){
+				module.exports = loadCSS;
+			}
+			else {
+				w.loadCSS = loadCSS;
+			}
+		}( typeof global !== "undefined" ? global : this ));
+
 
 
 

--- a/test/test.html
+++ b/test/test.html
@@ -64,7 +64,7 @@
 				ss.onloadcssdefined = onloadcssdefined;
 				onloadcssdefined(function() {
 					if( ss.media !== newMedia ){
-							ss.media = newMedia;
+						ss.media = newMedia;
 					}
 				});
 				return ss;

--- a/test/test.html
+++ b/test/test.html
@@ -20,6 +20,7 @@
 				// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
 				var doc = w.document;
 				var ss = doc.createElement( "link" );
+				var newMedia = media || "all";
 				var ref;
 				if( before ){
 					ref = before;
@@ -34,7 +35,6 @@
 				ss.href = href;
 				// temporarily set media to something inapplicable to ensure it'll fetch without blocking render
 				ss.media = "only x";
-				var newMedia = media || "all";
 
 
 				// Inject link
@@ -47,7 +47,7 @@
 					var i = sheets.length;
 					while( i-- ){
 						if( sheets[ i ].href === resolvedHref ){
-							return setTimeout(cb);
+							return cb();
 						}
 					}
 					setTimeout(function() {
@@ -70,8 +70,8 @@
 				return ss;
 			};
 			// commonjs
-			if( typeof module !== "undefined" ){
-				module.exports = loadCSS;
+			if( typeof exports !== "undefined" ){
+				exports.loadCSS = loadCSS;
 			}
 			else {
 				w.loadCSS = loadCSS;

--- a/test/test.html
+++ b/test/test.html
@@ -12,7 +12,7 @@
 		(function(w){
 			"use strict";
 			/* exported loadCSS */
-			w.loadCSS = function( href, before, media ){
+			var loadCSS = function( href, before, media ){
 				// Arguments explained:
 				// `href` [REQUIRED] is the URL for your CSS file.
 				// `before` [OPTIONAL] is the element the script should use as a reference for injecting our stylesheet <link> before
@@ -34,6 +34,8 @@
 				ss.href = href;
 				// temporarily set media to something inapplicable to ensure it'll fetch without blocking render
 				ss.media = "only x";
+				var newMedia = media || "all";
+
 
 				// Inject link
 					// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
@@ -45,7 +47,7 @@
 					var i = sheets.length;
 					while( i-- ){
 						if( sheets[ i ].href === resolvedHref ){
-							return cb();
+							return setTimeout(cb);
 						}
 					}
 					setTimeout(function() {
@@ -54,19 +56,35 @@
 				};
 
 				// once loaded, set link's media back to `all` so that the stylesheet applies once it loads
+				if( ss.addEventListener ){
+					ss.addEventListener( "load", function(){
+						this.media = newMedia;
+					});
+				}
 				ss.onloadcssdefined = onloadcssdefined;
 				onloadcssdefined(function() {
-					ss.media = media || "all";
+					if( ss.media !== newMedia ){
+							ss.media = newMedia;
+					}
 				});
 				return ss;
 			};
-		}(this));
+			// commonjs
+			if( typeof module !== "undefined" ){
+				module.exports = loadCSS;
+			}
+			else {
+				w.loadCSS = loadCSS;
+			}
+		}( typeof global !== "undefined" ? global : this ));
 
 
 
 
 
-			loadCSS( "http://scottjehl.com/css-temp/slow.php" );
+
+
+			loadCSS( "http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" );
 		</script>
 	</head>
 	<body>


### PR DESCRIPTION
fixes issue #110 double download in chrome.

in the process, I changed the commonjs exports mechanism to work within a qunit page (which exposes a global `module` method of its own). A quick test shows this still fetches via a `require` call as expected, so I think it's good to go. Review very welcome!