### PR TITLE
PhantomJS added to list of browsers not supporting "onload" for stylesheets

### DIFF
--- a/src/onloadCSS.js
+++ b/src/onloadCSS.js
@@ -21,9 +21,11 @@ function onloadCSS( ss, callback ) {
 	//	* Android 4.3 (Samsung Galaxy S4, Browserstack)
 	//	* Android 4.2 Browser (Samsung Galaxy SIII Mini GT-I8200L)
 	//	* Android 2.3 (Pantech Burst P9070)
+	//  * PhantomJS (Issue ref: https://github.com/ariya/phantomjs/issues/12332, https://github.com/dimaxweb/CSSLoader/issues/4)
 
-	// Weak inference targets Android < 4.4
- 	if( "isApplicationInstalled" in navigator && "onloadcssdefined" in ss ) {
-		ss.onloadcssdefined( newcb );
-	}
+    // Weak inference targets Android < 4.4
+    if ("isApplicationInstalled" in navigator && "onloadcssdefined" in ss ||
+    	/PhantomJS/.test(window.navigator.userAgent) && "onloadcssdefined" in ss) {
+        ss.onloadcssdefined(callback);
+    }
 }


### PR DESCRIPTION
I originally added this to version 0.1.8, but it looks like it's still not addressed in latest master branch, so merged it in.
Noticed this issue while trying to run regression tests with PhantomCSS. The "onload" handler never gets called. Giving it the same treatment as other non-supporting browsers seems to fix it.
I'm using PhantomJS 1.9.7, but it sounds like version 2.0.x still has the issue.
Refs: 
https://github.com/ariya/phantomjs/issues/12332
https://github.com/dimaxweb/CSSLoader/issues/4
