### PR TITLE
this fixes #134.

### DIFF
--- a/src/loadCSS.js
+++ b/src/loadCSS.js
@@ -10,7 +10,6 @@
 		// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
 		var doc = w.document;
 		var ss = doc.createElement( "link" );
-		var newMedia = media || "all";
 		var ref;
 		if( before ){
 			ref = before;
@@ -47,7 +46,7 @@
 			var i = sheets.length;
 			while( i-- ){
 				if( sheets[ i ].href === resolvedHref ){
-					return cb();
+					return cb.call( ss );
 				}
 			}
 			setTimeout(function() {
@@ -55,18 +54,19 @@
 			});
 		};
 
+		function loadCB(){
+			if( ss.addEventListener ){
+				ss.removeEventListener( "load", loadCB );
+			}
+			this.media = media || "all";
+		}
+
 		// once loaded, set link's media back to `all` so that the stylesheet applies once it loads
 		if( ss.addEventListener ){
-			ss.addEventListener( "load", function(){
-				this.media = newMedia;
-			});
+			ss.addEventListener( "load", loadCB);
 		}
 		ss.onloadcssdefined = onloadcssdefined;
-		onloadcssdefined(function() {
-			if( ss.media !== newMedia ){
-				ss.media = newMedia;
-			}
-		});
+		onloadcssdefined( loadCB );
 		return ss;
 	};
 	// commonjs

--- a/src/loadCSS.js
+++ b/src/loadCSS.js
@@ -46,7 +46,7 @@
 			var i = sheets.length;
 			while( i-- ){
 				if( sheets[ i ].href === resolvedHref ){
-					return cb.call( ss );
+					return cb();
 				}
 			}
 			setTimeout(function() {

--- a/src/loadCSS.js
+++ b/src/loadCSS.js
@@ -58,7 +58,7 @@
 			if( ss.addEventListener ){
 				ss.removeEventListener( "load", loadCB );
 			}
-			this.media = media || "all";
+			ss.media = media || "all";
 		}
 
 		// once loaded, set link's media back to `all` so that the stylesheet applies once it loads

--- a/test/preload.html
+++ b/test/preload.html
@@ -66,7 +66,7 @@
 					if( ss.addEventListener ){
 						ss.removeEventListener( "load", loadCB );
 					}
-					this.media = media || "all";
+					ss.media = media || "all";
 				}
 
 				// once loaded, set link's media back to `all` so that the stylesheet applies once it loads

--- a/test/preload.html
+++ b/test/preload.html
@@ -54,7 +54,7 @@
 					var i = sheets.length;
 					while( i-- ){
 						if( sheets[ i ].href === resolvedHref ){
-							return cb.call( ss );
+							return cb();
 						}
 					}
 					setTimeout(function() {
@@ -85,6 +85,7 @@
 				w.loadCSS = loadCSS;
 			}
 		}( typeof global !== "undefined" ? global : this ));
+
 
 
 

--- a/test/preload.html
+++ b/test/preload.html
@@ -6,11 +6,7 @@
 
 		<link rel="preload" href="http://scottjehl.com/css-temp/slow.php" as="style" onload="this.rel='stylesheet'">
 		<script>
-		/*!
-		loadCSS: load a CSS file asynchronously.
-		[c]2015 @scottjehl, Filament Group, Inc.
-		Licensed MIT
-		*/
+		/*! loadCSS: load a CSS file asynchronously. [c]2016 @scottjehl, Filament Group, Inc. Licensed MIT */
 		(function(w){
 			"use strict";
 			/* exported loadCSS */
@@ -22,7 +18,6 @@
 				// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
 				var doc = w.document;
 				var ss = doc.createElement( "link" );
-				var newMedia = media || "all";
 				var ref;
 				if( before ){
 					ref = before;
@@ -59,7 +54,7 @@
 					var i = sheets.length;
 					while( i-- ){
 						if( sheets[ i ].href === resolvedHref ){
-							return cb();
+							return cb.call( ss );
 						}
 					}
 					setTimeout(function() {
@@ -67,18 +62,19 @@
 					});
 				};
 
+				function loadCB(){
+					if( ss.addEventListener ){
+						ss.removeEventListener( "load", loadCB );
+					}
+					this.media = media || "all";
+				}
+
 				// once loaded, set link's media back to `all` so that the stylesheet applies once it loads
 				if( ss.addEventListener ){
-					ss.addEventListener( "load", function(){
-						this.media = newMedia;
-					});
+					ss.addEventListener( "load", loadCB);
 				}
 				ss.onloadcssdefined = onloadcssdefined;
-				onloadcssdefined(function() {
-					if( ss.media !== newMedia ){
-						ss.media = newMedia;
-					}
-				});
+				onloadcssdefined( loadCB );
 				return ss;
 			};
 			// commonjs
@@ -89,6 +85,7 @@
 				w.loadCSS = loadCSS;
 			}
 		}( typeof global !== "undefined" ? global : this ));
+
 
 
 		/* CSS rel=preload polyfill (from src/cssrelpreload.js) */

--- a/test/test-onload.html
+++ b/test/test-onload.html
@@ -52,7 +52,7 @@
 					var i = sheets.length;
 					while( i-- ){
 						if( sheets[ i ].href === resolvedHref ){
-							return cb.call( ss );
+							return cb();
 						}
 					}
 					setTimeout(function() {

--- a/test/test-onload.html
+++ b/test/test-onload.html
@@ -64,7 +64,7 @@
 					if( ss.addEventListener ){
 						ss.removeEventListener( "load", loadCB );
 					}
-					this.media = media || "all";
+					ss.media = media || "all";
 				}
 
 				// once loaded, set link's media back to `all` so that the stylesheet applies once it loads

--- a/test/test-onload.html
+++ b/test/test-onload.html
@@ -4,11 +4,7 @@
 		<title>Blocking Test</title>
 		<meta charset="utf-8">
 		<script>
-		/*!
-		loadCSS: load a CSS file asynchronously.
-		[c]2015 @scottjehl, Filament Group, Inc.
-		Licensed MIT
-		*/
+		/*! loadCSS: load a CSS file asynchronously. [c]2016 @scottjehl, Filament Group, Inc. Licensed MIT */
 		(function(w){
 			"use strict";
 			/* exported loadCSS */
@@ -20,7 +16,6 @@
 				// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
 				var doc = w.document;
 				var ss = doc.createElement( "link" );
-				var newMedia = media || "all";
 				var ref;
 				if( before ){
 					ref = before;
@@ -36,18 +31,28 @@
 				// temporarily set media to something inapplicable to ensure it'll fetch without blocking render
 				ss.media = "only x";
 
-
+				// wait until body is defined before injecting link. This ensures a non-blocking load in IE11.
+				function ready( cb ){
+					if( doc.body ){
+						return cb();
+					}
+					setTimeout(function(){
+						ready( cb );
+					});
+				}
 				// Inject link
 					// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
 					// Note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
-				ref.parentNode.insertBefore( ss, ( before ? ref : ref.nextSibling ) );
+				ready( function(){
+					ref.parentNode.insertBefore( ss, ( before ? ref : ref.nextSibling ) );
+				});
 				// A method (exposed on return object for external use) that mimics onload by polling until document.styleSheets until it includes the new sheet.
 				var onloadcssdefined = function( cb ){
 					var resolvedHref = ss.href;
 					var i = sheets.length;
 					while( i-- ){
 						if( sheets[ i ].href === resolvedHref ){
-							return setTimeout(cb);
+							return cb.call( ss );
 						}
 					}
 					setTimeout(function() {
@@ -55,28 +60,30 @@
 					});
 				};
 
+				function loadCB(){
+					if( ss.addEventListener ){
+						ss.removeEventListener( "load", loadCB );
+					}
+					this.media = media || "all";
+				}
+
 				// once loaded, set link's media back to `all` so that the stylesheet applies once it loads
 				if( ss.addEventListener ){
-					ss.addEventListener( "load", function(){
-						this.media = newMedia;
-					});
+					ss.addEventListener( "load", loadCB);
 				}
 				ss.onloadcssdefined = onloadcssdefined;
-				onloadcssdefined(function() {
-					if( ss.media !== newMedia ){
-							ss.media = newMedia;
-					}
-				});
+				onloadcssdefined( loadCB );
 				return ss;
 			};
 			// commonjs
-			if( typeof module !== "undefined" ){
-				module.exports = loadCSS;
+			if( typeof exports !== "undefined" ){
+				exports.loadCSS = loadCSS;
 			}
 			else {
 				w.loadCSS = loadCSS;
 			}
 		}( typeof global !== "undefined" ? global : this ));
+
 
 
 

--- a/test/test.html
+++ b/test/test.html
@@ -69,7 +69,7 @@
     			if( ss.addEventListener ){
     				ss.removeEventListener( "load", loadCB );
     			}
-    			this.media = media || "all";
+    			ss.media = media || "all";
     		}
 
     		// once loaded, set link's media back to `all` so that the stylesheet applies once it loads

--- a/test/test.html
+++ b/test/test.html
@@ -57,7 +57,7 @@
     			var i = sheets.length;
     			while( i-- ){
     				if( sheets[ i ].href === resolvedHref ){
-    					return cb.call( ss );
+    					return cb();
     				}
     			}
     			setTimeout(function() {
@@ -88,6 +88,7 @@
     		w.loadCSS = loadCSS;
     	}
     }( typeof global !== "undefined" ? global : this ));
+
 
 
 

--- a/test/test.html
+++ b/test/test.html
@@ -9,79 +9,85 @@
 			}
 		</style>
 		<script>
-		/*!
-		loadCSS: load a CSS file asynchronously.
-		[c]2015 @scottjehl, Filament Group, Inc.
-		Licensed MIT
-		*/
-		(function(w){
-			"use strict";
-			/* exported loadCSS */
-			var loadCSS = function( href, before, media ){
-				// Arguments explained:
-				// `href` [REQUIRED] is the URL for your CSS file.
-				// `before` [OPTIONAL] is the element the script should use as a reference for injecting our stylesheet <link> before
-					// By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM. However, you might desire a more specific location in your document.
-				// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
-				var doc = w.document;
-				var ss = doc.createElement( "link" );
-				var newMedia = media || "all";
-				var ref;
-				if( before ){
-					ref = before;
-				}
-				else {
-					var refs = ( doc.body || doc.getElementsByTagName( "head" )[ 0 ] ).childNodes;
-					ref = refs[ refs.length - 1];
-				}
+    /*! loadCSS: load a CSS file asynchronously. [c]2016 @scottjehl, Filament Group, Inc. Licensed MIT */
+    (function(w){
+    	"use strict";
+    	/* exported loadCSS */
+    	var loadCSS = function( href, before, media ){
+    		// Arguments explained:
+    		// `href` [REQUIRED] is the URL for your CSS file.
+    		// `before` [OPTIONAL] is the element the script should use as a reference for injecting our stylesheet <link> before
+    			// By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM. However, you might desire a more specific location in your document.
+    		// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
+    		var doc = w.document;
+    		var ss = doc.createElement( "link" );
+    		var ref;
+    		if( before ){
+    			ref = before;
+    		}
+    		else {
+    			var refs = ( doc.body || doc.getElementsByTagName( "head" )[ 0 ] ).childNodes;
+    			ref = refs[ refs.length - 1];
+    		}
 
-				var sheets = doc.styleSheets;
-				ss.rel = "stylesheet";
-				ss.href = href;
-				// temporarily set media to something inapplicable to ensure it'll fetch without blocking render
-				ss.media = "only x";
+    		var sheets = doc.styleSheets;
+    		ss.rel = "stylesheet";
+    		ss.href = href;
+    		// temporarily set media to something inapplicable to ensure it'll fetch without blocking render
+    		ss.media = "only x";
 
+    		// wait until body is defined before injecting link. This ensures a non-blocking load in IE11.
+    		function ready( cb ){
+    			if( doc.body ){
+    				return cb();
+    			}
+    			setTimeout(function(){
+    				ready( cb );
+    			});
+    		}
+    		// Inject link
+    			// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
+    			// Note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
+    		ready( function(){
+    			ref.parentNode.insertBefore( ss, ( before ? ref : ref.nextSibling ) );
+    		});
+    		// A method (exposed on return object for external use) that mimics onload by polling until document.styleSheets until it includes the new sheet.
+    		var onloadcssdefined = function( cb ){
+    			var resolvedHref = ss.href;
+    			var i = sheets.length;
+    			while( i-- ){
+    				if( sheets[ i ].href === resolvedHref ){
+    					return cb.call( ss );
+    				}
+    			}
+    			setTimeout(function() {
+    				onloadcssdefined( cb );
+    			});
+    		};
 
-				// Inject link
-					// Note: the ternary preserves the existing behavior of "before" argument, but we could choose to change the argument to "after" in a later release and standardize on ref.nextSibling for all refs
-					// Note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
-				ref.parentNode.insertBefore( ss, ( before ? ref : ref.nextSibling ) );
-				// A method (exposed on return object for external use) that mimics onload by polling until document.styleSheets until it includes the new sheet.
-				var onloadcssdefined = function( cb ){
-					var resolvedHref = ss.href;
-					var i = sheets.length;
-					while( i-- ){
-						if( sheets[ i ].href === resolvedHref ){
-							return cb();
-						}
-					}
-					setTimeout(function() {
-						onloadcssdefined( cb );
-					});
-				};
+    		function loadCB(){
+    			if( ss.addEventListener ){
+    				ss.removeEventListener( "load", loadCB );
+    			}
+    			this.media = media || "all";
+    		}
 
-				// once loaded, set link's media back to `all` so that the stylesheet applies once it loads
-				if( ss.addEventListener ){
-					ss.addEventListener( "load", function(){
-						this.media = newMedia;
-					});
-				}
-				ss.onloadcssdefined = onloadcssdefined;
-				onloadcssdefined(function() {
-					if( ss.media !== newMedia ){
-						ss.media = newMedia;
-					}
-				});
-				return ss;
-			};
-			// commonjs
-			if( typeof exports !== "undefined" ){
-				exports.loadCSS = loadCSS;
-			}
-			else {
-				w.loadCSS = loadCSS;
-			}
-		}( typeof global !== "undefined" ? global : this ));
+    		// once loaded, set link's media back to `all` so that the stylesheet applies once it loads
+    		if( ss.addEventListener ){
+    			ss.addEventListener( "load", loadCB);
+    		}
+    		ss.onloadcssdefined = onloadcssdefined;
+    		onloadcssdefined( loadCB );
+    		return ss;
+    	};
+    	// commonjs
+    	if( typeof exports !== "undefined" ){
+    		exports.loadCSS = loadCSS;
+    	}
+    	else {
+    		w.loadCSS = loadCSS;
+    	}
+    }( typeof global !== "undefined" ? global : this ));
 
 
 


### PR DESCRIPTION
 unbinding the onload handler immediately prevented the infinite loop that would otherwise happen from media attribute changes that would then trigger an onload event, and so on.