### PR TITLE
Add test case for as attribute

### DIFF
--- a/src/cssrelpreload.js
+++ b/src/cssrelpreload.js
@@ -18,9 +18,7 @@
     var links = w.document.getElementsByTagName( "link" );
     for( var i = 0; i < links.length; i++ ){
       var link = links[ i ];
-      if( link.rel === "preload" &&
-          link.getAttribute( "as" ) === "style" &&
-          link.dataset.loadcss !== "false" ){
+      if( link.rel === "preload" && link.getAttribute( "as" ) === "style" ){
         w.loadCSS( link.href, link );
         link.rel = null;
       }

--- a/src/cssrelpreload.js
+++ b/src/cssrelpreload.js
@@ -18,7 +18,9 @@
     var links = w.document.getElementsByTagName( "link" );
     for( var i = 0; i < links.length; i++ ){
       var link = links[ i ];
-      if( link.rel === "preload" && link.getAttribute( "as" ) === "style" ){
+      if( link.rel === "preload" &&
+          link.getAttribute( "as" ) === "style" &&
+          link.dataset.loadcss !== "false" ){
         w.loadCSS( link.href, link );
         link.rel = null;
       }

--- a/test/qunit/index.html
+++ b/test/qunit/index.html
@@ -7,6 +7,8 @@
 	<!-- Load local QUnit. -->
 	<link rel="stylesheet" href="./libs/qunit/qunit.css" media="screen">
 	<link rel="preload" href="files/preloadtest.css" id="preloadtest" as="style" onload="this.rel='stylesheet'">
+	<link rel="preload" href="files/preloadtest.css?1" id="optintest" as="style" data-loadcss="true">
+	<link rel="preload" href="files/preloadtest.css?2" id="optouttest" as="style" data-loadcss="false">
 	<script src="./libs/qunit/qunit.js"></script>
 	<!-- Load local lib and tests. -->
 	<script src="../../src/loadCSS.js" id="loadCSS"></script>

--- a/test/qunit/index.html
+++ b/test/qunit/index.html
@@ -7,7 +7,7 @@
 	<!-- Load local QUnit. -->
 	<link rel="stylesheet" href="./libs/qunit/qunit.css" media="screen">
 	<link rel="preload" href="files/preloadtest.css" id="preloadtest" as="style" onload="this.rel='stylesheet'">
-	<link rel="preload" href="files/preloadtest.css?astest" id="astest" as="style">
+	<link rel="preload" href="files/preloadtest.css?astest" id="astest" as="video">
 	<script src="./libs/qunit/qunit.js"></script>
 	<!-- Load local lib and tests. -->
 	<script src="../../src/loadCSS.js" id="loadCSS"></script>

--- a/test/qunit/index.html
+++ b/test/qunit/index.html
@@ -7,8 +7,7 @@
 	<!-- Load local QUnit. -->
 	<link rel="stylesheet" href="./libs/qunit/qunit.css" media="screen">
 	<link rel="preload" href="files/preloadtest.css" id="preloadtest" as="style" onload="this.rel='stylesheet'">
-	<link rel="preload" href="files/preloadtest.css?1" id="optintest" as="style" data-loadcss="true">
-	<link rel="preload" href="files/preloadtest.css?2" id="optouttest" as="style" data-loadcss="false">
+	<link rel="preload" href="files/preloadtest.css?astest" id="astest" as="style">
 	<script src="./libs/qunit/qunit.js"></script>
 	<!-- Load local lib and tests. -->
 	<script src="../../src/loadCSS.js" id="loadCSS"></script>

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -100,10 +100,11 @@
 	});
 
 	test( 'rel=preload polyfill respects attributes', function(){
-		expect(2);
+		expect(3);
 		var optInElem = document.getElementById('optintest');
 		var preloadHref = optInElem.getAttribute("href");
 		var optOutElem = document.getElementById('optouttest');
+		var asTestElem = document.getElementById('astest');
 
 		function loaded(){
 			return document.querySelector( 'link[href="'+ preloadHref +'"][rel="stylesheet"]' ) || document.querySelector( 'link[href="'+ optInElem.href +'"][rel="stylesheet"]' );
@@ -116,6 +117,7 @@
 			ok( loaded(), "opt in stylesheet is in dom and applied with a polyfill" );
 		}
 		ok(optOutElem.rel === "preload", "opt out stylesheet is not requested with a polyfill");
+		ok(asTestElem.rel === "preload", "stylesheet with unsupported 'as' attribute is not requested with a polyfill");
 
 	});
 

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -99,6 +99,26 @@
 		ok( typeof window.loadCSS.relpreload.support() === "boolean", "relpreload.support should be a bool" );
 	});
 
+	test( 'rel=preload polyfill respects attributes', function(){
+		expect(2);
+		var optInElem = document.getElementById('optintest');
+		var preloadHref = optInElem.getAttribute("href");
+		var optOutElem = document.getElementById('optouttest');
+
+		function loaded(){
+			return document.querySelector( 'link[href="'+ preloadHref +'"][rel="stylesheet"]' ) || document.querySelector( 'link[href="'+ optInElem.href +'"][rel="stylesheet"]' );
+		}
+
+		if( window.loadCSS.relpreload.support() ){
+			ok( loaded(), "opt in stylesheet is in dom and applied without a polyfill" );
+		}
+		else {
+			ok( loaded(), "opt in stylesheet is in dom and applied with a polyfill" );
+		}
+		ok(optOutElem.rel === "preload", "opt out stylesheet is not requested with a polyfill");
+
+	});
+
 	asyncTest( 'rel=preload stylesheet loads via polyfill', function(){
 		expect(1);
 		var preloadElem = document.getElementById("preloadtest");

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -100,23 +100,8 @@
 	});
 
 	test( 'rel=preload polyfill respects attributes', function(){
-		expect(3);
-		var optInElem = document.getElementById('optintest');
-		var preloadHref = optInElem.getAttribute("href");
-		var optOutElem = document.getElementById('optouttest');
+		expect(1);
 		var asTestElem = document.getElementById('astest');
-
-		function loaded(){
-			return document.querySelector( 'link[href="'+ preloadHref +'"][rel="stylesheet"]' ) || document.querySelector( 'link[href="'+ optInElem.href +'"][rel="stylesheet"]' );
-		}
-
-		if( window.loadCSS.relpreload.support() ){
-			ok( loaded(), "opt in stylesheet is in dom and applied without a polyfill" );
-		}
-		else {
-			ok( loaded(), "opt in stylesheet is in dom and applied with a polyfill" );
-		}
-		ok(optOutElem.rel === "preload", "opt out stylesheet is not requested with a polyfill");
 		ok(asTestElem.rel === "preload", "stylesheet with unsupported 'as' attribute is not requested with a polyfill");
 
 	});


### PR DESCRIPTION
Adds a test for the as="style" attribute, mostly to make sure the check remains in the loadCSS.relpreload poly method
