### PR TITLE
Fix for links called after this script

### DIFF
--- a/src/cssrelpreload.js
+++ b/src/cssrelpreload.js
@@ -1,5 +1,5 @@
 /*! CSS rel=preload polyfill. Depends on loadCSS function. [c]2016 @scottjehl, Filament Group, Inc. Licensed MIT  */
-(function( w ){
+(window.preloadpolyfill = function( w ){
   // rel=preload support test
   if( !w.loadCSS ){
     return;
@@ -40,4 +40,8 @@
       } )
     }
   }
-}( this ));
+})( this );
+
+document.addEventListener('DOMContentLoaded', function() {
+  preloadpolyfill(window);
+}, false);


### PR DESCRIPTION
Currently the polyfill script only works if the link tag with the css appears before the polyfill script (current versions of Firefox and IE).
This change would rerun the polyfill script after the DOM has fully loaded catching any link tags that appeared after the polyfill script.
Non-working Example using original script with link tag after script (view in firefox 46):
http://s.codepen.io/fatjester/debug/gMMrxv

Working Example using modified script (view in firefox 46):
http://s.codepen.io/fatjester/debug/gMMroe

This may cause an extremely slight delay in loading css files called after the polyfill script, but makes the script more compatible as a polyfill overall, and fixes circumstances where coding order is breaking the loading behavior.
