### PR TITLE
Fix for bug where script might not be called

### DIFF
--- a/src/cssrelpreload.js
+++ b/src/cssrelpreload.js
@@ -31,6 +31,7 @@
     var run = w.setInterval( rp.poly, 300 );
     if( w.addEventListener ){
       w.addEventListener( "load", function(){
+        rp.poly();
         w.clearInterval( run );
       } );
     }


### PR DESCRIPTION
Firefox and IE/Edge won't load links that appear after the polyfill.
What I think has been happening is the w.load event fires and clears the "run" interval before it has a chance to load styles that occur in between the last interval.
This addition calls the rp.poly function one last time to make sure it catches any that occur within that interval gap.
Original demo with link after polyfill (non-working in Firefox, IE, Edge):
http://s.codepen.io/fatjester/debug/gMMrxv

Modified version with link after polyfill (is working in Firefox, IE, Edge):
http://s.codepen.io/fatjester/debug/gMMrxv
#180
