### PR TITLE
Add media support to polyfill

### DIFF
--- a/src/cssrelpreload.js
+++ b/src/cssrelpreload.js
@@ -19,7 +19,7 @@
     for( var i = 0; i < links.length; i++ ){
       var link = links[ i ];
       if( link.rel === "preload" && link.getAttribute( "as" ) === "style" ){
-        w.loadCSS( link.href, link );
+        w.loadCSS( link.href, link, link.getAttribute( "media" ) );
         link.rel = null;
       }
     }


### PR DESCRIPTION
I noticed the polyfill ignores the media type set for the stylesheet. This change makes it possible to include print (or other) stylesheets in the same way.

Fixes #167
