### PR TITLE
Adds support for crossorigin attribute

### DIFF
--- a/src/loadCSS.js
+++ b/src/loadCSS.js
@@ -2,7 +2,7 @@
 (function(w){
 	"use strict";
 	/* exported loadCSS */
-	var loadCSS = function( href, before, media ){
+	var loadCSS = function( href, before, media, crossorigin ){
 		// Arguments explained:
 		// `href` [REQUIRED] is the URL for your CSS file.
 		// `before` [OPTIONAL] is the element the script should use as a reference for injecting our stylesheet <link> before
@@ -22,6 +22,10 @@
 		var sheets = doc.styleSheets;
 		ss.rel = "stylesheet";
 		ss.href = href;
+		if( crossorigin ){
+			ss.setAttribute("crossorigin", crossorigin);
+		}
+		
 		// temporarily set media to something inapplicable to ensure it'll fetch without blocking render
 		ss.media = "only x";
 


### PR DESCRIPTION
The crossorigin attribute is required to force the browser to send the `origin` header when requesting the stylesheet. Without this header, services like Amazon S3 won't send back an `access-control-allow-origin` header leading to CORS errors.