### PR TITLE
Update nodejs version in .travis.yml to latest lts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '0.11'
+  - 'lts/*'
 before_script:
   - npm install
 script: grunt -v


### PR DESCRIPTION
...to fix failing travis build.

Using latest nodejs lts version cause it's only used for build process atm and so build won't break again after several years ;)
See: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions

Btw: nodejs 0.12 reached also EOL