### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Referencing CSS stylesheets with `link[rel=stylesheet]` or `@import` causes brow
 
 * Latest release: https://github.com/filamentgroup/loadCSS/releases
 * NPM: https://www.npmjs.com/package/fg-loadcss
+* CDN: https://cdn.jsdelivr.net/npm/fg-loadcss/dist
 
 ## How To Use loadCSS (Recommended example)
 


### PR DESCRIPTION
I added a jsDelivr CDN link to your Readme, for people who want use it from a CDN or want to download the files directly (#258). 