### PR TITLE
Add support for link attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ If you're including and calling the loadCSS function (without the `rel=preload` 
 ```
 
 - `media`: You can optionally pass a string to the media argument to set the `media=""` of the stylesheet - the default value is `all`.
+- `attributes`: You can also optionally pass an Object of attribute name/attribute value pairs to set on the stylesheet. This can be used to specify Subresource Integrity attributes:
+```javascript
+loadCSS( 
+  "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css",
+  null,
+  null,
+  {
+    "crossorigin": "anonymous",
+    "integrity": "sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+  }
+);
+```
 
 #### Using with `onload`
 

--- a/src/loadCSS.js
+++ b/src/loadCSS.js
@@ -2,12 +2,13 @@
 (function(w){
 	"use strict";
 	/* exported loadCSS */
-	var loadCSS = function( href, before, media ){
+	var loadCSS = function( href, before, media, attributes ){
 		// Arguments explained:
 		// `href` [REQUIRED] is the URL for your CSS file.
 		// `before` [OPTIONAL] is the element the script should use as a reference for injecting our stylesheet <link> before
 		// By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM. However, you might desire a more specific location in your document.
 		// `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
+		// `attributes` [OPTIONAL] is the Object of attribute name/attribute value pairs to set on the stylesheet's DOM Element.
 		var doc = w.document;
 		var ss = doc.createElement( "link" );
 		var ref;
@@ -20,6 +21,14 @@
 		}
 
 		var sheets = doc.styleSheets;
+		// Set any of the provided attributes to the stylesheet DOM Element.
+		if( attributes ){
+			for( var attributeName in attributes ){
+				if( attributes.hasOwnProperty( attributeName ) ){
+					ss.setAttribute( attributeName, attributes[attributeName] );
+				}
+			}
+		}
 		ss.rel = "stylesheet";
 		ss.href = href;
 		// temporarily set media to something inapplicable to ensure it'll fetch without blocking render

--- a/test/attributes.html
+++ b/test/attributes.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width">
+		<title>Tests for "link" attributes</title>
+		<script type="text/javascript">
+			<!--#include virtual="../src/loadCSS.js" -->
+			<!--#include virtual="../src/onloadCSS.js" -->
+			(function () {
+				function loadBootstrapCSS( attributes ) {
+					const cacheBuster = Math.random();
+					return loadCSS( 
+						"https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" + '?cb=' + cacheBuster,
+						null,
+						null,
+						attributes
+					);
+				}
+
+				// Load Bootstrap with "incorrect" integrity attribute:
+				var incorrectCSSIntegrity = loadBootstrapCSS( {
+					"crossorigin": "anonymous",
+					"integrity": "sha384-incorrect-digest"
+				});
+				incorrectCSSIntegrity.onerror = function( error ) {
+					document.getElementById('incorrect-integrity').innerHTML = '<span class="text-success">Success!</span> Resource not loaded.';
+				}
+				onloadCSS( incorrectCSSIntegrity, function() {
+					document.getElementById('incorrect-integrity').innerHTML = '<span class="text-warning">Warning:</span> Resource should not have loaded.';
+				} );
+
+				// Load Bootstrap with "incorrect" crossorigin attribute:
+				var incorrectCSSCrossOrigin = loadBootstrapCSS( {
+					"crossorigin": "use-credentials",
+					"integrity": "sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+				});
+				incorrectCSSCrossOrigin.onerror = function( error ) {
+					document.getElementById('incorrect-crossorigin').innerHTML = '<span class="text-success">Success!</span> Resource not loaded.';
+				}
+				onloadCSS( incorrectCSSCrossOrigin, function() {
+					document.getElementById('incorrect-crossorigin').innerHTML = '<span class="text-warning">Warning:</span> Resource should not have loaded.';
+				} );
+
+				// Load Bootstrap with "correct" integrity attribute:
+				var correctCSSIntegrity = loadBootstrapCSS( {
+					"crossorigin": "anonymous",
+					"integrity": "sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+				} );
+				correctCSSIntegrity.onerror = function( error ) {
+					document.getElementById('correct-integrity').innerHTML = '<span class="text-warning">Warning:</span> Resource should have loaded.';
+				}
+				onloadCSS( correctCSSIntegrity, function() {
+					document.getElementById('correct-integrity').innerHTML = '<span class="text-success">Success!</span> Resource loaded.';
+				} );
+			})();
+		</script>
+	</head>
+	<body style="margin: 50px">
+		<h1>Tests for <code>link</code> attributes</h1>
+		<p>Support for <a href="https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity">Subresource Integrity</a> requires providing <code>integrity</code> and <code>crossorigin</code> attributes to the <code>link</code> Element.</p>
+		<p>By supplying an Object of attribue name/attribute value pairs as the fourth argument to <code>loadCSS()</code>, attributes can be set on the stylesheet's DOM Element.</p>
+		<pre><code>
+loadCSS( 
+	"https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css",
+	null,
+	null,
+	{
+		"title": "Bootstrap Styles",
+		"type": "text/css",
+		"crossorigin": "anonymous",
+		"integrity": "sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+		// etc.
+	}
+);
+		</code></pre>
+		<p>The following tests aim to validate the behavior of the API using correct and incorrect configurations:</p>
+
+		<table class="table">
+			<thead>
+				<tr>
+					<th>Test</th>
+					<th>Result</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Correct <code>integrity</code> digest</td>
+					<td id="correct-integrity">Running test...</td>
+				</tr>
+				<tr>
+					<td>Incorrect <code>integrity</code> digest</td>
+					<td id="incorrect-integrity">Running test...</td>
+				</tr>
+				<tr>
+					<td>Incorrect <code>crossorigin</code> attribute</td>
+					<td id="incorrect-crossorigin">Running test...</td>
+				</tr>
+			</tbody>
+		</table>
+	</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -29,6 +29,7 @@
 			<li><strong><a href="import.html">@import in Body</a>:</strong> Does an inline @import reference from the body of the page block rendering of content below it?</li>
 			<li><strong><a href="preload-control.html">Rel=preload Test</a>:</strong> standard link[rel=preload] with an onload handler to apply as a stylesheet once loaded. This will only work in supporting browsers.</li>
 			<li><strong><a href="dom-append.html">DOM appendChild</a>:</strong> Create a link element and append to the document.</li>
+			<li><strong><a href="attributes.html">Link attributes</a>:</strong> Do browsers supporting Subresource Integrity correctly handle link attributes?</li>
 		</ul>
 
 

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -48,6 +48,21 @@
 		});
 	});
 
+	asyncTest( 'loadCSS loads a CSS file with specific attributes', function(){
+		expect(3);
+		var attributes = {
+			title: "Default Style",
+			type: "text/css"
+		};
+		var ss = loadCSS("files/test.css", null, null, attributes);
+		onloadCSS( ss, function(){
+			ok("stylesheet loaded successfully");
+			equal(ss.title, attributes.title, "'title' attribute should be '" + attributes.title + "'");
+			equal(ss.type, attributes.type, "'type' attribute should be '" + attributes.type + "'");
+			start();
+		});
+	});
+
 	asyncTest( 'loadCSS sets media type before and after the stylesheet is loaded', function(){
 		expect(2);
 		var ss = loadCSS("files/test.css");


### PR DESCRIPTION
This makes it possible to provide additional attributes to the `<link>` Element of the stylesheet when using `loadCSS()`, as discussed in https://github.com/filamentgroup/loadCSS/pull/212.

[Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) can thus be implemented in browsers supporting the feature. As of late February 2018, 75% of global users can benefit from it according to [caniuse.com](https://caniuse.com/#feat=subresource-integrity)

Usage example:
```javascript
loadCSS( 
  "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css",
  null,
  null,
  {
    "crossorigin": "anonymous",
    "integrity": "sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
  }
);
```

This Pull Request also adds:
 * Documentation in the _README.md_ file
 * Unit Tests
 * In-browser usage example to validate behavior across multiple browsers.