### PR TITLE
Add badges npm, dependencies and devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # loadCSS
 
+[![NPM version](http://img.shields.io/npm/v/fg-loadcss.svg)](https://www.npmjs.org/package/fg-loadcss) [![dependencies Status](https://david-dm.org/filamentgroup/loadCSS/status.svg)](https://david-dm.org/filamentgroup/loadCSS) [![devDependencies Status](https://david-dm.org/filamentgroup/loadCSS/dev-status.svg)](https://david-dm.org/filamentgroup/loadCSS?type=dev)
+
 A function for loading CSS asynchronously
 [c]2017 @scottjehl, @zachleat [Filament Group, Inc.](https://www.filamentgroup.com/)
 Licensed MIT


### PR DESCRIPTION
These badges are added to the Readme file to inform visitors
to the repository of the latest version of all packages.
* redirection of the npm badge to the npmjs site
* dependencies and interdependencies of badges are redirect to the david-dm website.