### PR TITLE
Add badges npm, dependencies and devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # loadCSS
 
+[![NPM version](http://img.shields.io/npm/v/fg-loadcss.svg)](https://www.npmjs.org/package/fg-loadcss) [![dependencies Status](https://david-dm.org/filamentgroup/loadCSS/status.svg)](https://david-dm.org/filamentgroup/loadCSS) [![devDependencies Status](https://david-dm.org/filamentgroup/loadCSS/dev-status.svg)](https://david-dm.org/filamentgroup/loadCSS?type=dev)
+
 A function for loading CSS asynchronously
 [c]2017 @scottjehl, @zachleat [Filament Group, Inc.](https://www.filamentgroup.com/)
 Licensed MIT


### PR DESCRIPTION
Hello, 
I really appreciate your work on this loadCSS project. Indeed, it will be more interesting to integrate the badges (npm, dependencies, devDependencies) in the Readme.md file, in order to have an overview of the dependencies of the project, the version used and the latest available version.