### PR TITLE
Added support for "data-media"

### DIFF
--- a/src/cssrelpreload.js
+++ b/src/cssrelpreload.js
@@ -30,7 +30,7 @@
 	// then change that media back to its intended value on load
 	rp.bindMediaToggle = function( link ){
 		// remember existing media attr for ultimate state, or default to 'all'
-		var finalMedia = link.media || "all";
+		var finalMedia = link.getAttribute("data-media") || link.media || "all";
 
 		function enableStylesheet(){
 			link.media = finalMedia;


### PR DESCRIPTION
Chrome will not load the css file when the media attribute equals "print".
To work around this issue, I added support for the attribute "data-media", so that Chrome will happily preload the css and the fallback still works for other browsers.

I am using it like this:
`<link rel="preload" href="style.css" as="style" onload="this.rel='stylesheet';this.media='print'" data-media="print">`