### PR TITLE
minify JavaScript onload

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Referencing CSS stylesheets with `link[rel=stylesheet]` or `@import` causes brow
 
 As a primary pattern, we recommend loading asynchronous CSS like this from HTML:
 
-`<link rel="stylesheet" href="/path/to/my.css" media="print" onload="this.media='all'; this.onload=null;">`
+`<link rel="stylesheet" href="/path/to/my.css" media="print" onload="media='all';onload=null">`
 
 This article explains why this approach is best: https://www.filamentgroup.com/lab/load-css-simpler/
 

--- a/test/recommended.html
+++ b/test/recommended.html
@@ -3,7 +3,7 @@
 	<head>
 		<title>Recommended Pattern Test</title>
 		<meta charset="utf-8">
-        <link rel="stylesheet" href="slow.css" media="print" onload="this.media='all'; this.onload=null;">
+        <link rel="stylesheet" href="slow.css" media="print" onload="media='all';onload=null">
 	</head>
 	<body>
 		<p>This is a test file to demonstrate the recommended pattern for loading a stylesheet asynchronously.</p>


### PR DESCRIPTION
DOM 0 event listeners provide scopes that bound to the element: 

> scope
> [...]
> 5. If element is not null, then set scope to NewObjectEnvironment(element, true, scope).
> 
> — https://html.spec.whatwg.org/multipage/webappapis.html#internal-raw-uncompiled-handler

That means you can use:

```html
<img src="about:error" onerror="console.log(this,onerror,body,src)">
```

Will log:
1. `HTMLImageElement` instance
2. image DOM 0 event listener
3. `document.body`
4. image `src` property value